### PR TITLE
Replace find count

### DIFF
--- a/geocachingapi/const.py
+++ b/geocachingapi/const.py
@@ -30,7 +30,7 @@ CACHE_FIELDS_PARAMETER: str = ",".join([
                 "owner",
                 "postedCoordinates",
                 "favoritePoints",
-                #"findCount", # TODO: Include this another way, as this is not part of lite caches
+                "userData",
                 "placedDate",
                 "location"
             ])

--- a/geocachingapi/geocachingapi.py
+++ b/geocachingapi/geocachingapi.py
@@ -144,16 +144,16 @@ class GeocachingApi:
         if self._settings.nearby_caches_setting is not None:
             await self._update_nearby_caches()
         if len(self._settings.cache_codes) > 0:
-            await self._get_cache_info()
+            await self._update_tracked_caches()
 
         _LOGGER.info(f'Status updated.')
         return self._status
 
-    async def _get_cache_info(self, data: Dict[str, Any] = None) -> None:
+    async def _update_tracked_caches(self, data: Dict[str, Any] = None) -> None:
         assert self._status
         if data is None:
             caches_parameters = ",".join(self._settings.cache_codes)
-            data = await self._request("GET", f"/geocaches?referenceCodes={caches_parameters}&lite=true&fields={CACHE_FIELDS_PARAMETER}")
+            data = await self._request("GET", f"/geocaches?referenceCodes={caches_parameters}&fields={CACHE_FIELDS_PARAMETER}&lite=true")
         self._status.update_caches(data)
         _LOGGER.debug(f'Caches updated.')
 

--- a/geocachingapi/models.py
+++ b/geocachingapi/models.py
@@ -172,11 +172,8 @@ class GeocachingCache:
     favoritePoints: Optional[int] = None
     hiddenDate: Optional[datetime.date] = None
     foundDateTime: Optional[datetime] = None
+    foundByUser: Optional[bool] = None
     location: Optional[str] = None
-
-    @property
-    def found_by_user(self) -> bool:
-        return self.foundDateTime is not None
 
     def update_from_dict(self, data: Dict[str, Any]) -> None:
         self.reference_code = try_get_from_dict(data, "referenceCode", self.reference_code)
@@ -191,8 +188,10 @@ class GeocachingCache:
             user_data_obj: Dict[Any] = try_get_from_dict(data, "userData", {})
             found_date_time: datetime | None = try_get_from_dict(user_data_obj, "foundDate", None, lambda d: None if d is None else datetime.fromisoformat(d))
             self.foundDateTime = found_date_time
+            self.foundByUser = found_date_time is not None
         else:
             self.foundDateTime = None
+            self.foundByUser = None
         
         # Parse the location
         # Returns the location as "State, Country" if either could be parsed

--- a/geocachingapi/utils.py
+++ b/geocachingapi/utils.py
@@ -4,7 +4,7 @@ from typing import Dict, Any, Callable, Optional
 def try_get_from_dict(data: Dict[str, Any], key: str, original_value: Any, conversion: Optional[Callable[[Any], Any]] = None) -> Any:
     """Try to get value from dict, otherwise set default value"""
     if not key in data:
-        return None
+        return original_value
     
     value = data[key]
     if value is None:


### PR DESCRIPTION
* Change parser so original value is always returned when parsing fails, to align behavior
* Rename cache update function
* Remove cache find count as it is only available on full Geocaches, and calculating it manually through cache log requests would generate many more requests for so little data, and require support for pagination
* Add cache found by user and found by user date